### PR TITLE
Update backup email configuration in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,7 +80,7 @@ NEWSLETTER_RATE_LIMIT_PER_DAY=1000
 
 # Backup Configuration
 BACKUP_APP_NAME=newsletter-backup
-BACKUP_MAIL_TO=
+BACKUP_MAIL_TO=admin@newsletter.test
 BACKUP_DISK=s3
 
 # S3 Configuration for backups


### PR DESCRIPTION
The Spatie Backup package, on new installations, requires the `BACKUP_MAIL_TO` variable to be set; it does not accept an empty string.
When running the command `php artisan key:generate`, it throws an exception: `Spatie\Backup\Exceptions\InvalidConfig`.

With this fix you have a default email and you can change it later in the `.env` file